### PR TITLE
Support Brush as Resource

### DIFF
--- a/src/WinUIShell/UIElements/Brush.cs
+++ b/src/WinUIShell/UIElements/Brush.cs
@@ -13,8 +13,20 @@ public class Brush : WinUIShellObject
     internal Brush()
     {
     }
+
     internal Brush(ObjectId id)
     : base(id)
     {
+    }
+
+    internal Brush(Resource resource)
+        : base(resource.Id)
+    {
+    }
+
+    public static implicit operator Brush(Resource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        return new Brush(resource.Id);
     }
 }


### PR DESCRIPTION
Brush resource is supported with this PR:

```powershell
$resources = [Application]::Current.Resources
$stackPanel.Background = $resources['CardBackgroundFillColorDefaultBrush']
```