### PR TITLE
Make WinUIShell.Server self contained

### DIFF
--- a/src/WinUIShell.Server/WinUIShell.Server.csproj
+++ b/src/WinUIShell.Server/WinUIShell.Server.csproj
@@ -6,13 +6,15 @@
     <RootNamespace>WinUIShell.Server</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <SelfContained>true</SelfContained>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WindowsPackageType>None</WindowsPackageType>
     <EnableMsixTooling>true</EnableMsixTooling>
-    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <!-- <TreatWarningsAsErrors>True</TreatWarningsAsErrors> -->
     <AnalysisMode>All</AnalysisMode>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <!-- Need this to enable IDE0005 (Remove unnecessary usings/imports) on build (https://github.com/dotnet/roslyn/issues/41640) -->


### PR DESCRIPTION
This PR makes the server self contained. It makes the module size from 52MB to 303MB but eliminates users' manual dependency installs.

There is a bug in WASDK that generates analyzer warning on auto generated code so I disabled `TreatWarningsAsErrors`.

https://github.com/microsoft/WindowsAppSDK/issues/4857

```
.nuget\packages\microsoft.windowsappsdk\1.7.250310001\include\UndockedRegFreeWinRT-AutoInitializer.cs(18,36): warning CA5392: The method WindowsAppRuntime_EnsureIsLoaded didn't use DefaultDllImportSearchPaths attribute for P/Invokes. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392)
```