### PR TITLE
Add Font properties to Control

### DIFF
--- a/src/WinUIShell.Common/EnumTypeMapping.cs
+++ b/src/WinUIShell.Common/EnumTypeMapping.cs
@@ -14,6 +14,7 @@ internal sealed class EnumTypeMapping : Singleton<EnumTypeMapping>
         ("WinUIShell.DecodePixelType, WinUIShell", "Microsoft.UI.Xaml.Media.Imaging.DecodePixelType, Microsoft.WinUI"),
         ("WinUIShell.ElementTheme, WinUIShell", "Microsoft.UI.Xaml.ElementTheme, Microsoft.WinUI"),
         ("WinUIShell.EventCallbackRunspaceMode, WinUIShell", "WinUIShell.Server.EventCallbackRunspaceMode, WinUIShell.Server"),
+        ("WinUIShell.FocusState, WinUIShell", "Microsoft.UI.Xaml.FocusState, Microsoft.WinUI"),
         ("WinUIShell.FontStretch, WinUIShell", "Windows.UI.Text.FontStretch, Microsoft.Windows.SDK.NET"),
         ("WinUIShell.FontStyle, WinUIShell", "Windows.UI.Text.FontStyle, Microsoft.Windows.SDK.NET"),
         ("WinUIShell.GridUnitType, WinUIShell", "Microsoft.UI.Xaml.GridUnitType, Microsoft.WinUI"),

--- a/src/WinUIShell.Server/System/TypeMappingPrinter.cs
+++ b/src/WinUIShell.Server/System/TypeMappingPrinter.cs
@@ -125,6 +125,7 @@ internal static class TypeMappingPrinter
         Print(typeof(Microsoft.UI.Xaml.Media.Imaging.DecodePixelType));
         Print(typeof(Microsoft.UI.Xaml.ElementTheme));
         Print(typeof(EventCallbackRunspaceMode));
+        Print(typeof(Microsoft.UI.Xaml.FocusState));
         Print(typeof(Windows.UI.Text.FontStretch));
         Print(typeof(Windows.UI.Text.FontStyle));
         Print(typeof(Microsoft.UI.Xaml.GridUnitType));

--- a/src/WinUIShell/UIElements/Control.cs
+++ b/src/WinUIShell/UIElements/Control.cs
@@ -39,7 +39,11 @@ public class Control : FrameworkElement
         set => PropertyAccessor.Set(Id, nameof(CornerRadius), value?.Id);
     }
 
-    //public FontFamily FontFamily
+    public FontFamily FontFamily
+    {
+        get => PropertyAccessor.Get<FontFamily>(Id, nameof(FontFamily))!;
+        set => PropertyAccessor.Set(Id, nameof(FontFamily), value?.Id);
+    }
 
     public double FontSize
     {
@@ -47,9 +51,23 @@ public class Control : FrameworkElement
         set => PropertyAccessor.Set(Id, nameof(FontSize), value);
     }
 
-    //public FontStretch FontStretch
-    //public FontStyle FontStyle
-    //public FontWeight FontWeight
+    public FontStretch FontStretch
+    {
+        get => PropertyAccessor.Get<FontStretch>(Id, nameof(FontStretch))!;
+        set => PropertyAccessor.Set(Id, nameof(FontStretch), value);
+    }
+
+    public FontStyle FontStyle
+    {
+        get => PropertyAccessor.Get<FontStyle>(Id, nameof(FontStyle))!;
+        set => PropertyAccessor.Set(Id, nameof(FontStyle), value);
+    }
+
+    public FontWeight FontWeight
+    {
+        get => PropertyAccessor.Get<FontWeight>(Id, nameof(FontWeight))!;
+        set => PropertyAccessor.Set(Id, nameof(FontWeight), value?.Id);
+    }
 
     public Brush Foreground
     {

--- a/src/WinUIShell/UIElements/FocusState.cs
+++ b/src/WinUIShell/UIElements/FocusState.cs
@@ -1,0 +1,11 @@
+﻿namespace WinUIShell;
+
+#pragma warning disable CA1720 // Identifier contains type name
+public enum FocusState
+{
+    Unfocused,
+    Pointer,
+    Keyboard,
+    Programmatic
+}
+#pragma warning restore CA1720 // Identifier contains type name

--- a/src/WinUIShell/UIElements/UIElement.cs
+++ b/src/WinUIShell/UIElements/UIElement.cs
@@ -46,6 +46,11 @@ public class UIElement : WinUIShellObject
     {
     }
 
+    public bool Focus(FocusState value)
+    {
+        return CommandClient.Get().InvokeMethodAndGetResult<bool>(Id, nameof(Focus), value);
+    }
+
     public void AddKeyDown(ScriptBlock scriptBlock, object? argumentList = null)
     {
         AddKeyDown(new EventCallback


### PR DESCRIPTION
This PR adds the following based on #31 and #32:

- `FontFamily`, `FontStretch`, `FontStyle` and `FontWeight` properties to `Control`
- `Focus` method to `UIElement`